### PR TITLE
Fixing login logic when email already exist with different provider id

### DIFF
--- a/app/Http/Controllers/SocialiteController.php
+++ b/app/Http/Controllers/SocialiteController.php
@@ -16,34 +16,42 @@ class SocialiteController extends Controller
     //     return Socialite::driver('facebook')->redirect();
     // }
 
-    public function providerAuthentication($provider){
-        // $User = Socialite::driver('google')->user();
-
-        // dd($User);
-        try {
-            if ($provider){
-                $provider_user = Socialite::driver($provider)->user();
-                $user = User::where('email', $provider_user->email)->first();
-            if ($user){
-                Auth::login($user);
-                return redirect('/');
-            } else {
-                $new_user = User::create([
-                    'nama' => ucwords($provider_user->name),
-                    'email' => $provider_user->email,
-                    'phone' => '0987654321',
-                    'password' => 'password',
-                    'confirm_password' => 'password' ,
-                ]);
-
-                Auth::login($new_user);
-                return redirect('/');
-            }
-        } abort(404);
-        } catch (\Throwable $th){
-            abort(404);
+    public function providerAuthentication($provider)
+{
+    // Mengambil data user dari provider (misalnya, Google)
+    $user = Socialite::driver($provider)->user();
+    
+    // Cek apakah email sudah terdaftar di database
+    $existingUser = User::where('email', $user->email)->first();
+    
+    if ($existingUser) {
+        // Jika email sudah terdaftar dan provider_id terisi (not null)
+        if (is_null($existingUser->provider_id)) {
+            // Mengarahkan ke rute /register dengan session emailTerdaftar
+            return to_route('auth')->with('emailTerdaftar', 'Email sudah terdaftar dengan metode login lain');
         }
+        
+        // Jika email terdaftar tapi belum menggunakan metode login lain (misalnya, belum ada provider_id)
+        // Proses login biasa, bisa diarahkan ke halaman dashboard atau lainnya
+        Auth::login($existingUser);
+        return redirect()->intended('/');
     }
+    
+    // Jika email belum terdaftar, buat user baru
+    $newUser = User::create([
+        'name' => $user->getName(),
+        'email' => $user->getEmail(),
+        'phone' => '0987654321',
+        'id_provider' => $user->getId(),
+        // kolom lain yang diperlukan seperti 'password' jika dibutuhkan
+    ]);
+    
+    // Login otomatis setelah registrasi
+    auth::login($newUser);
+    
+    return redirect()->intended('/');
+}
+
     // public function facebookAuthentication($provider){
     //     $User = Socialite::driver($provider)->user();
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -22,7 +22,7 @@ class User extends Authenticatable
         'email',
         'phone',
         'password',
-        'confirm_password',
+        'id_provider',
     ];
 
     /**

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -16,9 +16,9 @@ return new class extends Migration
             $table->string('nama');
             $table->string('email')->unique();
             $table->string('phone')->unique();
+            $table->string('id_provider')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
-            $table->string('confirm_password');
             $table->rememberToken();
             $table->timestamps();
         });

--- a/resources/views/auth/index.blade.php
+++ b/resources/views/auth/index.blade.php
@@ -32,6 +32,7 @@
                 <div class="flex justify-center items-center">
                     @if(session()->has('success'))<div class="mb-4 text-sm text-green-800 rounded-lg dark:text-green-400" role="alert"><span class="font-medium">{{ session('success') }}</div>@endif
                     @if(session()->has('loginError'))<div class="mb-4 text-sm text-red-800 rounded-lg dark:text-red-400" role="alert"><span class="font-medium">{{ session('loginError') }}</div>@endif
+                    @if(session()->has('emailTerdaftar'))<div class="mb-4 text-sm text-red-800 rounded-lg dark:text-red-400" role="alert"><span class="font-medium">{{ session('emailTerdaftar') }}</div>@endif
                 </div>
 
                 <form action="{{ route('login') }}" method="POST" class="space-y-6" autocomplete="off">
@@ -205,8 +206,8 @@
             if (sessionSuccess) {
                 // Menjalankan showLoginForm jika session success ada
                 showRegisterForm();
-            } else{
-                showLoginForm();
+            } else if (sessionEmail){
+                showForm();
             }
             
 

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -89,14 +89,18 @@
 
                 <div class="dropdown">
                     <div tabindex="0" role="button" class="btn m-1">
-                        <a class="btn btn-circle">
-                            <img src="{{ asset('img/navbar/profile.png') }}" class="max-h-20 h-auto w-auto" alt="Profile">
-                        </a>
+                        <form action="/logout" method="POST">
+                            @csrf
+                            <button type="submit" class="w-full text-left">Logout</button>
+                        </form>
                     </div>
                     <ul tabindex="0"
                         class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow absolute right-0">
                         <li>
-                            <a href="/profile">Profile</a> <!-- Halaman profil langsung -->
+                            <form action="/logout" method="POST">
+                                @csrf
+                                <button type="submit" class="w-full text-left">Logout</button>
+                            </form>
                         </li>
                         <li>
                             @auth


### PR DESCRIPTION
Perubahan : 

- Memperbaiki logika login, jika user pernah login menggunakan **provider yang berbeda** dengan **provider yang akan digunakan sekarang**, dan **email** yang digunakan **sama**,dan juga provider yang digunakan sekarang **belum terverifikasi** di akun dengan **provider yang pernah digunakan sebelumnya**, maka user akan ter-direct kembali ke **halaman auth** dengan pesan "Email sudah terdaftar dengan metode login lain"